### PR TITLE
Accept math block inline in the Markdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,6 +152,68 @@ function math_block(state, start, end, silent){
     return true;
 }
 
+function math_inline_block(state, silent) {
+    var start, match, token, res, pos, esc_count;
+
+    if(state.src.slice(state.pos, state.pos+2) !== "$$") { return false; }
+
+    res = isValidDelim(state, state.pos + 1);
+    if (!res.can_open) {
+        if (!silent) { state.pending += "$$"; }
+        state.pos += 2;
+        return true;
+    }
+
+    // First check for and bypass all properly escaped delimieters
+    // This loop will assume that the first leading backtick can not
+    // be the first character in state.src, which is known since
+    // we have found an opening delimieter already.
+    start = state.pos + 2;
+    match = start;
+    while ( (match = state.src.indexOf("$$", match)) !== -1) {
+        // Found potential $$, look for escapes, pos will point to
+        // first non escape when complete
+        pos = match - 1;
+        while (state.src[pos] === "\\") { pos -= 1; }
+
+        // Even number of escapes, potential closing delimiter found
+        if ( ((match - pos) % 2) == 1 ) { break; }
+        match += 2;
+    }
+
+    // No closing delimter found.  Consume $$ and continue.
+    if (match === -1) {
+        if (!silent) { state.pending += "$$"; }
+        state.pos = start;
+        return true;
+    }
+
+    // Check if we have empty content, ie: $$$$.  Do not parse.
+    if (match - start === 0) {
+        if (!silent) { state.pending += "$$$$"; }
+        state.pos = start + 2;
+        return true;
+    }
+
+    // Check for valid closing delimiter
+    res = isValidDelim(state, match+1);
+    if (!res.can_close) {
+        if (!silent) { state.pending += "$$"; }
+        state.pos = start;
+        return true;
+    }
+
+    if (!silent) {
+        token         = state.push('math_block', 'math', 0);
+        token.block   = true;
+        token.markup  = "$$";
+        token.content = state.src.slice(start, match);
+    }
+
+    state.pos = match + 2;
+    return true;
+}
+
 module.exports = function math_plugin(md, options) {
     // Default options
 
@@ -189,9 +251,11 @@ module.exports = function math_plugin(md, options) {
     }
 
     md.inline.ruler.after('escape', 'math_inline', math_inline);
+    md.inline.ruler.after('escape', 'math_inline_block', math_inline_block);
     md.block.ruler.after('blockquote', 'math_block', math_block, {
         alt: [ 'paragraph', 'reference', 'blockquote', 'list' ]
     });
     md.renderer.rules.math_inline = inlineRenderer;
+    md.renderer.rules.math_inline_block = blockRenderer;
     md.renderer.rules.math_block = blockRenderer;
 };


### PR DESCRIPTION
Render math in $$..$$ but written inline as block.

Example:
```
In short: $$\hat {y}_i = h(X_i) = \sum_{j=1}^{m} (\sum_{k=0}^h w_k \times x_{ij}^k)$$ is the equation we want.
```

This may keep writing Markdown with math simple (as I do it on the train while commuting :).