### PR TITLE
Update katex version to 0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ var result = md.render('# Math Rulez! \n  $\\sqrt{3x-1}+(1+x)^2$');
 
 Include the KaTeX stylesheet in your html:
 ```html
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0/katex.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.0/katex.min.css">
 ```
 
 If you're using the default markdown-it parser, I also recommend the [github stylesheet](https://github.com/sindresorhus/github-markdown-css):

--- a/package-lock.json
+++ b/package-lock.json
@@ -228,8 +228,8 @@
             }
         },
         "katex": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/katex/-/katex-0.9.0.tgz",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/katex/-/katex-0.10.0.tgz",
             "integrity": "sha512-lp3x90LT1tDZBW2tjLheJ98wmRMRjUHwk4QpaswT9bhqoQZ+XA4cPcjcQBxgOQNwaOSt6ZeL/a6GKQ1of3LFxQ==",
             "requires": {
                 "match-at": "0.1.1"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "author": "Takahiro Ethan Ikeuchi @iktakahiro",
     "license": "MIT",
     "dependencies": {
-        "katex": "^0.9.0"
+        "katex": "^0.10.0"
     },
     "devDependencies": {
         "markdown-it": "^8.4.1",


### PR DESCRIPTION
A new KaTex version was released on Oct 29, 2018. Let's update dependencies