### PR TITLE
Update katex to 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -368,9 +368,9 @@
             }
         },
         "katex": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/katex/-/katex-0.11.1.tgz",
-            "integrity": "sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
+            "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
             "requires": {
                 "commander": "^2.19.0"
             }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "author": "Takahiro Ethan Ikeuchi @iktakahiro",
     "license": "MIT",
     "dependencies": {
-        "katex": "0.11.1"
+        "katex": "^0.12.0"
     },
     "devDependencies": {
         "markdown-it": "11.0.0",


### PR DESCRIPTION
KaTeX 0.12.0 was released about 3 months ago, so hopefully it doesn't break anything

[KaTeX v0.12.0 release notes](https://github.com/KaTeX/KaTeX/releases/tag/v0.12.0)